### PR TITLE
`MMD` loss implemented, `discrepancy_loss` (`str`) added as a constructor param

### DIFF
--- a/.github/workflows/nets-pullrequest-pytest.yml
+++ b/.github/workflows/nets-pullrequest-pytest.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest
-          pytest --disable-warnings
+          pytest src/nets/tests/unit --disable-warnings
+          pytest src/nets/tests/integration --disable-warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ classifiers = ["Programming Language :: Python :: 3"]
 requires-python = ">=3.7"
 dependencies = [
     "tensorflow",
-    "pytest"
+    "pytest",
+    "tensorflow-model-remediation"
 ]

--- a/src/nets/models/factory.py
+++ b/src/nets/models/factory.py
@@ -4,7 +4,7 @@ Model class factories.
 """
 
 from nets.models.mlp import MLP
-from nets.models.vae import GaussianVAE
+from nets.models.vae import GaussianDenseVAE
 
 
 class MLPFactory(object):
@@ -17,8 +17,8 @@ class MLPFactory(object):
         output_dim = config.get("output_dim")
         activation = config.get("activation", "relu")
         output_activation = config.get("output_activation", None)
-        k_regularizer = config.get("kernel_regularizer", None)
-        a_regularizer = config.get("activity_regularizer", None)
+        kernel_regularizer = config.get("kernel_regularizer", None)
+        activity_regularizer = config.get("activity_regularizer", None)
 
         return MLP(
                 hidden_dims=hidden_dims,
@@ -26,12 +26,12 @@ class MLPFactory(object):
                 input_shape=input_shape,
                 activation=activation,
                 output_activation=output_activation,
-                kernel_regularizer=k_regularizer,
-                activity_regularizer=a_regularizer
+                kernel_regularizer=kernel_regularizer,
+                activity_regularizer=activity_regularizer
         )
 
 
-class VAEFactory(object):
+class GaussianDenseVAEFactory(object):
 
     @classmethod
     def apply(cls, config):
@@ -41,15 +41,17 @@ class VAEFactory(object):
         input_shape = config.get("input_shape", None)
         activation = config.get("activation", "relu")
         activity_regularizer = config.get("activity_regularizer", None)
+        kernel_regularizer = config.get("kernel_regularizer", None)
         reconstruction_activation = config.get("reconstruction_activation", None)
         sparse_flag = config.get("sparse_flag", False)
 
-        return GaussianVAE(
+        return GaussianDenseVAE(
             encoding_dims=encoding_dims,
             latent_dim=latent_dim,
             input_shape=input_shape,
             activation=activation,
             activity_regularizer=activity_regularizer,
+            kernel_regularizer=kernel_regularizer,
             reconstruction_activation=reconstruction_activation,
             sparse_flag=sparse_flag
         )

--- a/src/nets/models/factory.py
+++ b/src/nets/models/factory.py
@@ -4,7 +4,7 @@ Model class factories.
 """
 
 from nets.models.mlp import MLP
-from nets.models.vae import VAE
+from nets.models.vae import GaussianVAE
 
 
 class MLPFactory(object):
@@ -44,7 +44,7 @@ class VAEFactory(object):
         reconstruction_activation = config.get("reconstruction_activation", None)
         sparse_flag = config.get("sparse_flag", False)
 
-        return VAE(
+        return GaussianVAE(
             encoding_dims=encoding_dims,
             latent_dim=latent_dim,
             input_shape=input_shape,

--- a/src/nets/models/vae.py
+++ b/src/nets/models/vae.py
@@ -12,7 +12,7 @@ from nets.layers.sampling import GaussianSampling
 
 
 @tf.keras.utils.register_keras_serializable("nets")
-class DenseGaussianVariationalEncoder(BaseModel):
+class GaussianDenseVariationalEncoder(BaseModel):
 
     def __init__(self, encoding_dims, latent_dim, activation="relu",
                  activity_regularizer=None, kernel_regularizer=None,
@@ -65,12 +65,13 @@ class DenseGaussianVariationalEncoder(BaseModel):
         return z_mean, z_log_var, z
 
     def get_config(self):
-        config = super(DenseGaussianVariationalEncoder, self).get_config()
+        config = super(GaussianDenseVariationalEncoder, self).get_config()
         config.update({
             "encoding_dims": self._encoding_dims,
             "latent_dim": self._latent_dim,
             "activation": self._activation,
             "activity_regularizer": self._activity_regularizer,
+            "kernel_regularizer": self._kernel_regularizer,
             "sparse_flag": self._sparse_flag
         })
         return config
@@ -81,7 +82,7 @@ class DenseGaussianVariationalEncoder(BaseModel):
 
 
 @tf.keras.utils.register_keras_serializable("nets")
-class DenseGaussianVariationalDecoder(BaseModel):
+class GaussianDenseVariationalDecoder(BaseModel):
 
     def __init__(self, decoding_dims, output_dim, activation="relu",
                  activity_regularizer=None, kernel_regularizer=None,
@@ -94,6 +95,7 @@ class DenseGaussianVariationalDecoder(BaseModel):
         self._output_dim = output_dim
         self._activation = activation
         self._activity_regularizer = activity_regularizer
+        self._kernel_regularizer = kernel_regularizer
         self._reconstruction_activation = reconstruction_activation
         self._sparse_flag = sparse_flag
 
@@ -129,12 +131,13 @@ class DenseGaussianVariationalDecoder(BaseModel):
         return self._output_layer(self._decoding_block(self._input_layer(inputs)))
 
     def get_config(self):
-        config = super(DenseGaussianVariationalDecoder, self).get_config()
+        config = super(GaussianDenseVariationalDecoder, self).get_config()
         config.update({
             "decoding_dims": self._decoding_dims,
             "output_dim": self._output_dim,
             "activation": self._activation,
             "activity_regularizer": self._activity_regularizer,
+            "kernel_regularizer": self._kernel_regularizer,
             "reconstruction_activation": self._reconstruction_activation,
             "sparse_flag": self._sparse_flag
         })
@@ -146,7 +149,7 @@ class DenseGaussianVariationalDecoder(BaseModel):
 
 
 @tf.keras.utils.register_keras_serializable("nets")
-class GaussianVAE(BaseModel):
+class GaussianDenseVAE(BaseModel):
     """
     Variational autoencoder with dense encoding/decoding layers.
     """
@@ -187,7 +190,7 @@ class GaussianVAE(BaseModel):
         ]
 
         # Encoder
-        self._encoder = DenseGaussianVariationalEncoder(
+        self._encoder = GaussianDenseVariationalEncoder(
             encoding_dims=self._encoding_dims,
             latent_dim=self._latent_dim,
             activation=self._activation,
@@ -214,7 +217,7 @@ class GaussianVAE(BaseModel):
 
         self._encoder.build(self._input_shape)
 
-        self._decoder = DenseGaussianVariationalDecoder(
+        self._decoder = GaussianDenseVariationalDecoder(
             decoding_dims=self._encoding_dims[::-1],
             output_dim=self._input_shape[-1],
             activation=self._activation,
@@ -288,13 +291,14 @@ class GaussianVAE(BaseModel):
         return self._decoder.__call__(latent)
 
     def get_config(self):
-        config = super(GaussianVAE, self).get_config()
+        config = super(GaussianDenseVAE, self).get_config()
         config.update({
             "encoding_dims": self._encoding_dims,
             "latent_dim": self._latent_dim,
             "activation": self._activation,
             "reconstruction_activation": self._reconstruction_activation,
             "activity_regularizer": self._activity_regularizer,
+            "kernel_regularizer": self._kernel_regularizer,
             "discrepancy_loss": self._discrepancy_loss,
             "sparse_flag": self._sparse_flag
         })

--- a/src/nets/tests/integration/models/test_vae.py
+++ b/src/nets/tests/integration/models/test_vae.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import shutil
 import tensorflow as tf
-from nets.models.vae import VAE
+from nets.models.vae import GaussianVAE
 from nets.utils import get_obj
 
 from nets.tests.utils import *
@@ -60,7 +60,7 @@ class TestVAE(unittest.TestCase):
         Instantiate and return a model with the default params and compiled
         with the default loss and optimizer.
         """
-        model = VAE(
+        model = GaussianVAE(
             encoding_dims=self._encoding_dims,
             latent_dim=self._latent_dim,
             activation=self._activation,
@@ -86,7 +86,7 @@ class TestVAE(unittest.TestCase):
         Test that model creation works when specifying the input shape in the
          model constructor (triggering a call of `build` on construction).
         """
-        model = VAE(
+        model = GaussianVAE(
                 input_shape=self._input_shape,
                 encoding_dims=self._encoding_dims,
                 latent_dim=self._latent_dim,
@@ -123,7 +123,7 @@ class TestVAE(unittest.TestCase):
         activity_regularizer = {"L2": {}}
         encoding_dims = [64, 32, 16]
 
-        model = VAE(
+        model = GaussianVAE(
                 encoding_dims=encoding_dims,
                 activation=self._activation,
                 latent_dim=self._latent_dim,

--- a/src/nets/tests/integration/models/test_vae.py
+++ b/src/nets/tests/integration/models/test_vae.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import shutil
 import tensorflow as tf
-from nets.models.vae import GaussianVAE
+from nets.models.vae import GaussianDenseVAE
 from nets.utils import get_obj
 
 from nets.tests.utils import *
@@ -60,7 +60,7 @@ class TestVAE(unittest.TestCase):
         Instantiate and return a model with the default params and compiled
         with the default loss and optimizer.
         """
-        model = GaussianVAE(
+        model = GaussianDenseVAE(
             encoding_dims=self._encoding_dims,
             latent_dim=self._latent_dim,
             activation=self._activation,
@@ -86,7 +86,7 @@ class TestVAE(unittest.TestCase):
         Test that model creation works when specifying the input shape in the
          model constructor (triggering a call of `build` on construction).
         """
-        model = GaussianVAE(
+        model = GaussianDenseVAE(
                 input_shape=self._input_shape,
                 encoding_dims=self._encoding_dims,
                 latent_dim=self._latent_dim,
@@ -123,7 +123,7 @@ class TestVAE(unittest.TestCase):
         activity_regularizer = {"L2": {}}
         encoding_dims = [64, 32, 16]
 
-        model = GaussianVAE(
+        model = GaussianDenseVAE(
                 encoding_dims=encoding_dims,
                 activation=self._activation,
                 latent_dim=self._latent_dim,

--- a/src/nets/tests/unit/models/test_factory.py
+++ b/src/nets/tests/unit/models/test_factory.py
@@ -1,7 +1,7 @@
 import unittest
 
 import tensorflow as tf
-from nets.models.factory import VAEFactory, MLPFactory
+from nets.models.factory import GaussianDenseVAEFactory, MLPFactory
 from nets.utils import get_obj
 
 from nets.tests.utils import try_except_assertion_decorator
@@ -50,7 +50,7 @@ class TestFactory(unittest.TestCase):
 
     @try_except_assertion_decorator
     def test_vae_factory_basic(self):
-        vae = VAEFactory.apply(self._default_vae_config)
+        vae = GaussianDenseVAEFactory.apply(self._default_vae_config)
         vae.build(self._input_shape)
 
     @try_except_assertion_decorator
@@ -60,4 +60,4 @@ class TestFactory(unittest.TestCase):
                 "activity_regularizer": get_obj(tf.keras.regularizers, {"L2": {}}),
                 "kernel_regularizer": get_obj(tf.keras.regularizers, {"L2": {}})
         })
-        _ = VAEFactory.apply(self._default_vae_config)
+        _ = GaussianDenseVAEFactory.apply(self._default_vae_config)


### PR DESCRIPTION
- VAE now defaults to `mmd` for the new constructor param `discrepancy_loss`
- `kld` (KL divergence) can also be used if desired, although not recommended
- Breaking change in naming conventions for VAE models to make room for new VAE variants and potential trait-mixin style design patterns