### PR TITLE
Adding spectral norm layer wrapper for block layers, constructor param to all models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ requires-python = ">=3.7"
 dependencies = [
     "tensorflow",
     "pytest",
-    "tensorflow-model-remediation"
+    "tensorflow-model-remediation",
+    "tensorflow-addons"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ dependencies = [
     "tensorflow",
     "pytest",
     "tensorflow-model-remediation",
-    "tensorflow-addons"
+    "tensorflow-addons",
+    "typeguard >= 2.13, < 3"
 ]

--- a/src/nets/layers/conv.py
+++ b/src/nets/layers/conv.py
@@ -57,14 +57,14 @@ class ConvBlock(tf.keras.layers.Layer):
         self._block_layers = []
         for f, k, s, p in zip(self._filters, self._kernel, self._stride, self._padding):
 
-            conv_layer = tf.keras.layers.Conv2D(
+            conv = tf.keras.layers.Conv2D(
                     f, k, strides=s, padding=p, activation=self._activation
             )
 
             if self._spectral_norm:
-                conv_layer = tfa.layers.SpectralNormalization(conv_layer)
-
-            self._block_layers.append(conv_layer)
+                self._block_layers.append(tfa.layers.SpectralNormalization(conv))
+            else:
+                self._block_layers.append(conv)
 
             if self._batch_norm:
                 self._block_layers.append(tf.keras.layers.BatchNormalization())

--- a/src/nets/layers/conv.py
+++ b/src/nets/layers/conv.py
@@ -1,12 +1,14 @@
 
 import tensorflow as tf
+import tensorflow_addons as tfa
 
 
 @tf.keras.utils.register_keras_serializable
 class ConvBlock(tf.keras.layers.Layer):
 
     def __init__(self, filters, kernel=3, stride=(1,1), padding="same",
-            activation="relu", pool=True, batch_norm=False, **kwargs):
+                 activation="relu", pool=True, batch_norm=False,
+                 spectral_norm=True, **kwargs):
         """
         2d CNN Block (series of convolution and pooling ops). Assumes reshaping
          and input formatting is done already, and expects the input shape to
@@ -21,6 +23,7 @@ class ConvBlock(tf.keras.layers.Layer):
         :param activation: Activation function (str)
         :param pool: Flag to add pooling layer after each convolution (bool)
         :param batch_norm: Flag to add batch normalization after each convolution (bool)
+        :param spectral_norm: Flag to apply spectral normalization to conv layer weights (bool)
         :return:
         """
 
@@ -28,7 +31,8 @@ class ConvBlock(tf.keras.layers.Layer):
 
         self._pool_flag = pool
         self._activation = activation
-        self._batch_norm_flag = batch_norm
+        self._batch_norm = batch_norm
+        self._spectral_norm = spectral_norm
 
         if isinstance(filters, int):
             self._filters = [filters]
@@ -52,10 +56,17 @@ class ConvBlock(tf.keras.layers.Layer):
 
         self._block_layers = []
         for f, k, s, p in zip(self._filters, self._kernel, self._stride, self._padding):
-            self._block_layers.append(tf.keras.layers.Conv2D(
+
+            conv_layer = tf.keras.layers.Conv2D(
                     f, k, strides=s, padding=p, activation=self._activation
-            ))
-            if self._batch_norm_flag:
+            )
+
+            if self._spectral_norm:
+                conv_layer = tfa.layers.SpectralNormalization(conv_layer)
+
+            self._block_layers.append(conv_layer)
+
+            if self._batch_norm:
                 self._block_layers.append(tf.keras.layers.BatchNormalization())
             if self._pool_flag:
                 self._block_layers.append(tf.keras.layers.MaxPooling2D())
@@ -80,7 +91,8 @@ class ConvBlock(tf.keras.layers.Layer):
             "padding": self._padding,
             "activation": self._activation,
             "pool": self._pool_flag,
-            "batch_norm": self._batch_norm_flag
+            "batch_norm": self._batch_norm,
+            "spectral_norm": self._spectral_norm
         })
         return config
 

--- a/src/nets/layers/dense.py
+++ b/src/nets/layers/dense.py
@@ -26,7 +26,7 @@ class DenseBlock(tf.keras.layers.Layer):
 
         self._block_layers = []
         for d, a in zip(self._hidden_dims, self._activation):
-            layer = tf.keras.layers.Dense(
+            dense = tf.keras.layers.Dense(
                     units=d,
                     activation=a,
                     kernel_regularizer=self._kernel_regularizer,
@@ -34,9 +34,9 @@ class DenseBlock(tf.keras.layers.Layer):
             )
 
             if self._spectral_norm:
-                layer = tfa.layers.SpectralNormalization(layer)
-
-            self._block_layers.append(layer)
+                self._block_layers.append(tfa.layers.SpectralNormalization(layer=dense))
+            else:
+                self._block_layers.append(dense)
 
     def call(self, inputs, training=False):
         """

--- a/src/nets/layers/dense.py
+++ b/src/nets/layers/dense.py
@@ -1,12 +1,13 @@
 
 import tensorflow as tf
+import tensorflow_addons as tfa
 
 
 @tf.keras.utils.register_keras_serializable("nets")
 class DenseBlock(tf.keras.layers.Layer):
 
     def __init__(self, hidden_dims, activation="relu", kernel_regularizer=None,
-                 activity_regularizer=None, **kwargs):
+                 activity_regularizer=None, spectral_norm=False, **kwargs):
 
         super(DenseBlock, self).__init__(**kwargs)
 
@@ -21,16 +22,21 @@ class DenseBlock(tf.keras.layers.Layer):
 
         self._kernel_regularizer = kernel_regularizer
         self._activity_regularizer = activity_regularizer
+        self._spectral_norm = spectral_norm
 
-        self._block_layers = [
-            tf.keras.layers.Dense(
+        self._block_layers = []
+        for d, a in zip(self._hidden_dims, self._activation):
+            layer = tf.keras.layers.Dense(
                     units=d,
                     activation=a,
                     kernel_regularizer=self._kernel_regularizer,
                     activity_regularizer=self._activity_regularizer
             )
-            for d, a in zip(self._hidden_dims, self._activation)
-        ]
+
+            if self._spectral_norm:
+                layer = tfa.layers.SpectralNormalization(layer)
+
+            self._block_layers.append(layer)
 
     def call(self, inputs, training=False):
         """
@@ -49,7 +55,8 @@ class DenseBlock(tf.keras.layers.Layer):
             "hidden_dims": self._hidden_dims,
             "activation": self._activation,
             "activity_regularizer": self._activity_regularizer,
-            "kernel_regularizer": self._kernel_regularizer
+            "kernel_regularizer": self._kernel_regularizer,
+            "spectral_norm": self._spectral_norm
         })
         return config
 

--- a/src/nets/models/factory.py
+++ b/src/nets/models/factory.py
@@ -19,6 +19,7 @@ class MLPFactory(object):
         output_activation = config.get("output_activation", None)
         kernel_regularizer = config.get("kernel_regularizer", None)
         activity_regularizer = config.get("activity_regularizer", None)
+        spectral_norm = config.get("spectral_norm", False)
 
         return MLP(
                 hidden_dims=hidden_dims,
@@ -27,7 +28,8 @@ class MLPFactory(object):
                 activation=activation,
                 output_activation=output_activation,
                 kernel_regularizer=kernel_regularizer,
-                activity_regularizer=activity_regularizer
+                activity_regularizer=activity_regularizer,
+                spectral_norm=spectral_norm
         )
 
 
@@ -42,6 +44,7 @@ class GaussianDenseVAEFactory(object):
         activation = config.get("activation", "relu")
         activity_regularizer = config.get("activity_regularizer", None)
         kernel_regularizer = config.get("kernel_regularizer", None)
+        spectral_norm = config.get("spectral_norm", False)
         reconstruction_activation = config.get("reconstruction_activation", None)
         sparse_flag = config.get("sparse_flag", False)
 
@@ -52,6 +55,7 @@ class GaussianDenseVAEFactory(object):
             activation=activation,
             activity_regularizer=activity_regularizer,
             kernel_regularizer=kernel_regularizer,
+            spectral_norm = spectral_norm,
             reconstruction_activation=reconstruction_activation,
             sparse_flag=sparse_flag
         )

--- a/src/nets/models/mlp.py
+++ b/src/nets/models/mlp.py
@@ -12,9 +12,10 @@ from nets.models.base import BaseModel
 @tf.keras.utils.register_keras_serializable("nets")
 class MLP(BaseModel):
 
-    def __init__(self, hidden_dims, output_dim, input_shape=None, activation="relu",
-                 output_activation="softmax", kernel_regularizer=None,
-                 activity_regularizer=None, name="MLP", **kwargs):
+    def __init__(self, hidden_dims, output_dim, input_shape=None,
+                 activation="relu", output_activation="softmax",
+                 kernel_regularizer=None, activity_regularizer=None,
+                 spectral_norm=False, name="MLP", **kwargs):
 
         super().__init__(name=name,  **kwargs)
 
@@ -25,12 +26,14 @@ class MLP(BaseModel):
         self._output_activation = output_activation
         self._kernel_regularizer = kernel_regularizer
         self._activity_regularizer = activity_regularizer
+        self._spectral_norm = spectral_norm
 
         self._dense_block = DenseBlock(
             hidden_dims=self._hidden_dims,
             activation=self._activation,
             kernel_regularizer=self._kernel_regularizer,
-            activity_regularizer=self._activity_regularizer
+            activity_regularizer=self._activity_regularizer,
+            spectral_norm=self._spectral_norm
         )
 
         self._output_layer = tf.keras.layers.Dense(
@@ -89,7 +92,8 @@ class MLP(BaseModel):
             "activation": self._activation,
             "output_activation": self._output_activation,
             "kernel_regularizer": self._kernel_regularizer,
-            "activity_regularizer": self._activity_regularizer
+            "activity_regularizer": self._activity_regularizer,
+            "spectral_norm": self._spectral_norm
         })
         return config
 

--- a/src/nets/models/vae.py
+++ b/src/nets/models/vae.py
@@ -16,8 +16,7 @@ class GaussianDenseVariationalEncoder(BaseModel):
 
     def __init__(self, encoding_dims, latent_dim, activation="relu",
                  activity_regularizer=None, kernel_regularizer=None,
-                 reconstruction_activation="linear", sparse_flag=False,
-                 name="DGVE", **kwargs):
+                 spectral_norm=False, sparse_flag=False, name="DGVE", **kwargs):
 
         super().__init__(name=name, **kwargs)
 
@@ -26,6 +25,7 @@ class GaussianDenseVariationalEncoder(BaseModel):
         self._activation = activation
         self._activity_regularizer = activity_regularizer
         self._kernel_regularizer = kernel_regularizer
+        self._spectral_norm = spectral_norm
         self._sparse_flag = sparse_flag
 
         self._input_layer = None
@@ -33,7 +33,8 @@ class GaussianDenseVariationalEncoder(BaseModel):
                 hidden_dims=self._encoding_dims,
                 activation=self._activation,
                 activity_regularizer=self._activity_regularizer,
-                kernel_regularizer=self._kernel_regularizer
+                kernel_regularizer=self._kernel_regularizer,
+                spectral_norm=self._spectral_norm
         )
         self._latent_mean = tf.keras.layers.Dense(self._latent_dim)
         self._latent_log_var = tf.keras.layers.Dense(self._latent_dim)
@@ -72,6 +73,7 @@ class GaussianDenseVariationalEncoder(BaseModel):
             "activation": self._activation,
             "activity_regularizer": self._activity_regularizer,
             "kernel_regularizer": self._kernel_regularizer,
+            "spectral_norm": self._spectral_norm,
             "sparse_flag": self._sparse_flag
         })
         return config
@@ -86,8 +88,8 @@ class GaussianDenseVariationalDecoder(BaseModel):
 
     def __init__(self, decoding_dims, output_dim, activation="relu",
                  activity_regularizer=None, kernel_regularizer=None,
-                 reconstruction_activation="linear", sparse_flag=False,
-                 name="DGVD", **kwargs):
+                 spectral_norm=False, reconstruction_activation="linear",
+                 sparse_flag=False, name="DGVD", **kwargs):
 
         super().__init__(name=name, **kwargs)
 
@@ -96,6 +98,7 @@ class GaussianDenseVariationalDecoder(BaseModel):
         self._activation = activation
         self._activity_regularizer = activity_regularizer
         self._kernel_regularizer = kernel_regularizer
+        self._spectral_norm = spectral_norm
         self._reconstruction_activation = reconstruction_activation
         self._sparse_flag = sparse_flag
 
@@ -138,6 +141,7 @@ class GaussianDenseVariationalDecoder(BaseModel):
             "activation": self._activation,
             "activity_regularizer": self._activity_regularizer,
             "kernel_regularizer": self._kernel_regularizer,
+            "spectral_norm": self._spectral_norm,
             "reconstruction_activation": self._reconstruction_activation,
             "sparse_flag": self._sparse_flag
         })
@@ -156,8 +160,9 @@ class GaussianDenseVAE(BaseModel):
 
     def __init__(self, encoding_dims, latent_dim, input_shape=None,
                  activation="relu", activity_regularizer=None,
-                 kernel_regularizer=None, reconstruction_activation=None,
-                 discrepancy_loss="mmd", sparse_flag=False, name="VAE", **kwargs):
+                 kernel_regularizer=None, spectral_norm=False,
+                 reconstruction_activation="linear", discrepancy_loss="mmd",
+                 sparse_flag=False, name="VAE", **kwargs):
 
         super().__init__(name=name,  **kwargs)
 
@@ -167,6 +172,7 @@ class GaussianDenseVAE(BaseModel):
         self._activation = activation
         self._activity_regularizer = activity_regularizer
         self._kernel_regularizer = kernel_regularizer
+        self._spectral_norm = spectral_norm
         self._reconstruction_activation = reconstruction_activation
         self._discrepancy_loss = discrepancy_loss
         self._sparse_flag = sparse_flag
@@ -195,7 +201,8 @@ class GaussianDenseVAE(BaseModel):
             latent_dim=self._latent_dim,
             activation=self._activation,
             activity_regularizer=self._activity_regularizer,
-            kernel_regularizer=self._kernel_regularizer
+            kernel_regularizer=self._kernel_regularizer,
+            spectral_norm=self._spectral_norm
         )
 
         # Input layer and decoder can only be defined now if we
@@ -222,6 +229,7 @@ class GaussianDenseVAE(BaseModel):
             output_dim=self._input_shape[-1],
             activation=self._activation,
             activity_regularizer=self._activity_regularizer,
+            spectral_norm=self._spectral_norm,
             kernel_regularizer=self._kernel_regularizer,
             reconstruction_activation=self._reconstruction_activation
         )
@@ -299,6 +307,7 @@ class GaussianDenseVAE(BaseModel):
             "reconstruction_activation": self._reconstruction_activation,
             "activity_regularizer": self._activity_regularizer,
             "kernel_regularizer": self._kernel_regularizer,
+            "spectral_norm": self._spectral_norm,
             "discrepancy_loss": self._discrepancy_loss,
             "sparse_flag": self._sparse_flag
         })

--- a/src/nets/tests/integration/models/test_mlp.py
+++ b/src/nets/tests/integration/models/test_mlp.py
@@ -121,6 +121,7 @@ class TestMLP(unittest.TestCase):
         loss = {"MeanAbsoluteError": {}}
         activity_regularizer =  {"L2": {}}
         hidden_dims = [64, 32, 16]
+        spectral_norm = True
 
         model = MLP(
                 hidden_dims=hidden_dims,
@@ -129,7 +130,8 @@ class TestMLP(unittest.TestCase):
                 output_activation=self._output_activation,
                 activity_regularizer=get_obj(
                         tf.keras.regularizers, activity_regularizer
-                )
+                ),
+                spectral_norm=spectral_norm
             )
         model.build(input_shape=self._input_shape)
         model.compile(

--- a/src/nets/tests/unit/models/test_factory.py
+++ b/src/nets/tests/unit/models/test_factory.py
@@ -44,7 +44,8 @@ class TestFactory(unittest.TestCase):
         self._default_mlp_config.update({
             "input_shape": self._input_shape,
             "activity_regularizer": get_obj(tf.keras.regularizers, {"L2": {}}),
-            "kernel_regularizer": get_obj(tf.keras.regularizers, {"L2": {}})
+            "kernel_regularizer": get_obj(tf.keras.regularizers, {"L2": {}}),
+            "spectral_norm": True
         })
         _ = MLPFactory.apply(self._default_mlp_config)
 
@@ -58,6 +59,7 @@ class TestFactory(unittest.TestCase):
         self._default_vae_config.update({
                 "input_shape": self._input_shape,
                 "activity_regularizer": get_obj(tf.keras.regularizers, {"L2": {}}),
-                "kernel_regularizer": get_obj(tf.keras.regularizers, {"L2": {}})
+                "kernel_regularizer": get_obj(tf.keras.regularizers, {"L2": {}}),
+                "spectral_norm": True
         })
         _ = GaussianDenseVAEFactory.apply(self._default_vae_config)


### PR DESCRIPTION
- Spectral normalization layer wrapper from `tensorflow_addons` added to dense and conv block layers
- `spectral_norm` flag parameter added to model constructors
- Model fit and factory tests modified to include `spectral_norm` constructor param
- Tangentially, a GDVAE `decoder` save/load test was added to complement the `encoder` save/load test 