### PR TITLE
Basic ranking model

### DIFF
--- a/src/nets/models/recommender/twotower.py
+++ b/src/nets/models/recommender/twotower.py
@@ -1,5 +1,6 @@
 
 import tensorflow as tf
+import tensorflow_recommenders as tfrs
 
 from nets.models.base import BaseTFRecommenderModel
 from nets.layers.recommender import StringEmbedding
@@ -45,43 +46,91 @@ class TwoTowerMixin(BaseTFRecommenderModel):
 
 
 @tf.keras.utils.register_keras_serializable("nets")
-class SimpleEmbeddingTwoTower(TwoTowerMixin):
-
-    def __init__(self, task, embedding_dim, users, items, user_features,
+class TwoTowerRetrieval(TwoTowerMixin):
+    """
+    The basic two tower model takes pre-defined and/or pre-trained models
+    for both the user and item models.
+    """
+    def __init__(self, user_model, item_model, user_features,
                  item_features, name="SimpleEmbeddedTwoTower"):
+
         super().__init__(name=name)
 
-        self._task = task
-        self._embedding_dim = embedding_dim
-        self._users = users
-        self._items = items
+        self._task = tfrs.tasks.Retrieval()
+
+        self._user_model = user_model
+        self._item_model = item_model
         self._user_features = user_features
         self._item_features = item_features
 
-        self._item_model = StringEmbedding(
-            vocab=self._items,
-            embedding_dim=self._embedding_dim
+
+@tf.keras.utils.register_keras_serializable("nets")
+class SimpleEmbeddingTwoTowerRetrieval(TwoTowerRetrieval):
+
+    def __init__(self, embedding_dim, users, items, user_features,
+                 item_features, name="SimpleEmbeddedTwoTower"):
+
+        self._embedding_dim = embedding_dim
+        self._users = users
+        self._items = items
+
+        user_model = StringEmbedding(
+            vocab=self._users, embedding_dim=self._embedding_dim
         )
 
-        self._user_model = StringEmbedding(
-            vocab=self._users,
-            embedding_dim=self._embedding_dim
+        item_model = StringEmbedding(
+            vocab=self._items, embedding_dim=self._embedding_dim
+        )
+
+        super().__init__(
+            user_model=user_model,
+            item_model=item_model,
+            user_features=user_features,
+            item_features=item_features,
+            name=name
         )
 
 
 @tf.keras.utils.register_keras_serializable("nets")
-class FineTuningTwoTower(TwoTowerMixin):
+class TwoTowerRatingsRanking(TwoTowerMixin):
+
     """
     The fine-tuning two tower model takes pre-defined and pre-trained models
     for both the user and item models.
     """
-    def __init__(self, task, user_model, item_model, user_features,
-                 item_features, name="SimpleEmbeddedTwoTower"):
+    def __init__(self, ratings_model, user_model, item_model, user_features,
+                 item_features, ratings_label, name="TwoTowerRatingsRanking"):
 
         super().__init__(name=name)
 
+        self._ratings_model = ratings_model
         self._user_model = user_model
         self._item_model = item_model
-        self._task = task
         self._user_features = user_features
         self._item_features = item_features
+        self._ratings_label = ratings_label
+
+        # Basic task, can be overwritten / paramterized as needed
+        self._task = tfrs.tasks.Ranking(
+                loss = tf.keras.losses.MeanSquaredError(),
+                metrics=[tf.keras.metrics.RootMeanSquaredError()]
+        )
+
+    def call(self, inputs):
+
+        user_features, item_features = inputs
+        user_embedding = self.user_model(user_features)
+        item_embedding = self.item_model(item_features)
+
+        return self._ratings_model.__call__(tf.concat(
+                values=[user_embedding, item_embedding], axis=1
+        ))
+
+    def compute_loss(self, features, training=False):
+
+        labels = features.pop(self._ratings_label)
+        feature_tuple = (
+            features[self.user_features], features[self.item_features]
+        )
+        rating_predictions = self.__call__(feature_tuple)
+        return self.task(labels=labels, predictions=rating_predictions)

--- a/src/nets/tests/integration/models/base.py
+++ b/src/nets/tests/integration/models/base.py
@@ -15,7 +15,7 @@ from nets.tests.utils import try_except_assertion_decorator, \
 class ModelIntegrationABC(ABC):
 
     """
-    Model integration test ABC (ABC of the ABC flavors) --
+    Model integration test ABC. Defines the following --
 
         - `setUpClass` should load and store data for model train testing
         - `tearDownClass` should clean up any data stored and remaining
@@ -86,7 +86,7 @@ class ModelIntegrationABC(ABC):
 
 class ModelIntegrationMixin(object):
     """
-    Common concrete classes for all integration mixin flavors.
+    Common concrete methods for all integration mixin flavors.
         - `tearDown` deletes any artifacts saved at `temp` (may need to be
         overwritten by certain children)
         - `test_build` is a generic test for creating the default model
@@ -124,7 +124,7 @@ class ModelIntegrationMixin(object):
 class RecommenderIntegrationMixin(ModelIntegrationMixin):
 
     """
-    ABC for recommender model testing. Implements several of the base ABCs
+    Mixin for recommender model testing. Implements several of the base ABCs
     abstract methods:
         - `setUpClass` reads and preps movielens data
         - `tearDownClass` deletes movielens data and any artifacts at temp path
@@ -193,7 +193,7 @@ class RecommenderIntegrationMixin(ModelIntegrationMixin):
 class DenseIntegrationMixin(ModelIntegrationMixin):
 
     """
-    ABC for dense model testing. Implements several of the base ABCs
+    Mixin for dense model testing. Implements several of the base ABCs
     abstract methods:
         - `setUpClass` reads and preps mnist data
         - `tearDownClass` deletes mnist movielens data

--- a/src/nets/tests/integration/models/base.py
+++ b/src/nets/tests/integration/models/base.py
@@ -146,6 +146,7 @@ class RecommenderIntegrationMixin(ModelIntegrationMixin):
             .map(lambda x: {
                 "movie_title": x["movie_title"],
                 "user_id": x["user_id"],
+                "user_rating": x["user_rating"]
             })
 
         shuffled_ratings = ratings.shuffle(10000, seed=1, reshuffle_each_iteration=False)
@@ -184,6 +185,7 @@ class RecommenderIntegrationMixin(ModelIntegrationMixin):
         self._embedding_dim = 32
         self._user_features = "user_id"
         self._item_features = "movie_title"
+        self._ratings_label = "user_rating"
         self._activation = "relu"
         self._optimizer = {"Adam": {"learning_rate": 0.001}}
         self._task = tfrs.tasks.Retrieval()

--- a/src/nets/tests/integration/models/recommender/test_twotower.py
+++ b/src/nets/tests/integration/models/recommender/test_twotower.py
@@ -2,33 +2,40 @@
 import tensorflow as tf
 import tensorflow_recommenders as tfrs
 import os
-from unittest import TestCase as TC, skip
+from unittest import TestCase as TC
 
-from nets.models.recommender.twotower import SimpleEmbeddingTwoTower, \
-    FineTuningTwoTower
+from nets.models.recommender.twotower import SimpleEmbeddingTwoTowerRetrieval, \
+    TwoTowerRetrieval, TwoTowerRatingsRanking
 from nets.layers.recommender import StringEmbedding
+from nets.models.mlp import MLP
 from nets.utils import get_obj
 
-from nets.tests.utils import try_except_assertion_decorator, \
-    TrainSanityAssertionCallback
+from nets.tests.utils import try_except_assertion_decorator
 from nets.tests.integration.models.base import ModelIntegrationABC, \
     RecommenderIntegrationMixin
 
 
-class TestSimpleEmbeddingTwoTower(RecommenderIntegrationMixin, ModelIntegrationABC, TC):
+class TestTwoTowerRetrieval(RecommenderIntegrationMixin, ModelIntegrationABC, TC):
+    """
+    Fine tuning tester. For simplicity, here we simply create
+    """
 
-    temp = os.path.join(os.getcwd(), "simpletwotower-tmp-model")
+    temp = os.path.join(os.getcwd(), "twotower-tmp-model")
 
     def _generate_default_compiled_model(self):
         """
         Instantiate and return a model with the default params and compiled
-        with the default loss and optimizer defined in setUp
+        with the default loss and optimizer defined in setUp.
         """
-        model = SimpleEmbeddingTwoTower(
-                task=self._task,
-                embedding_dim=self._embedding_dim,
-                users=self._users,
-                items=self._items,
+        user_model = StringEmbedding(
+                vocab=self._users, embedding_dim=self._embedding_dim
+        )
+        item_model = StringEmbedding(
+                vocab=self._items, embedding_dim=self._embedding_dim
+        )
+        model = TwoTowerRetrieval(
+                user_model=user_model,
+                item_model=item_model,
                 user_features=self._user_features,
                 item_features=self._item_features
         )
@@ -36,31 +43,6 @@ class TestSimpleEmbeddingTwoTower(RecommenderIntegrationMixin, ModelIntegrationA
             optimizer=get_obj(tf.keras.optimizers, self._optimizer)
         )
         return model
-
-    def test_fit_ranking(self):
-        """
-        Test that training "works" (by the definition of TrainSanityCallback)
-        for the default model. Assertion is done directly in
-        TrainSanityCallback.
-        """
-        ranking_task = tfrs.tasks.Ranking()
-
-        model = SimpleEmbeddingTwoTower(
-                task=ranking_task,
-                embedding_dim=self._embedding_dim,
-                users=self._users,
-                items=self._items,
-                user_features=self._user_features,
-                item_features=self._item_features
-        )
-        model.compile(
-            optimizer=get_obj(tf.keras.optimizers, self._optimizer)
-        )
-        model.fit(
-                self._train,
-                epochs=self._epochs,
-                callbacks=[TrainSanityAssertionCallback()]
-        )
 
     @try_except_assertion_decorator
     def test_predict(self):
@@ -103,12 +85,74 @@ class TestSimpleEmbeddingTwoTower(RecommenderIntegrationMixin, ModelIntegrationA
         _ = tf.saved_model.load(self.temp)
 
 
-class TestFineTuningTwoTower(RecommenderIntegrationMixin, ModelIntegrationABC, TC):
+class TestSimpleEmbeddingTwoTowerRetrieval(RecommenderIntegrationMixin, ModelIntegrationABC, TC):
+
+    temp = os.path.join(os.getcwd(), "twotower-tmp-model")
+
+    def _generate_default_compiled_model(self):
+        """
+        Instantiate and return a model with the default params and compiled
+        with the default loss and optimizer defined in setUp
+        """
+        model = SimpleEmbeddingTwoTowerRetrieval(
+                embedding_dim=self._embedding_dim,
+                users=self._users,
+                items=self._items,
+                user_features=self._user_features,
+                item_features=self._item_features
+        )
+        model.compile(
+            optimizer=get_obj(tf.keras.optimizers, self._optimizer)
+        )
+        return model
+
+    @try_except_assertion_decorator
+    def test_predict(self):
+        """
+        Test that prediction works.
+        """
+        model = self._generate_default_compiled_model()
+        model.fit(
+                self._train,
+                epochs=self._epochs
+        )
+        index = tfrs.layers.factorized_top_k.BruteForce(model.user_model)
+        index.index_from_dataset(
+                tf.data.Dataset.zip((
+                    self._movies, self._movies.map(model.item_model)
+                ))
+        )
+
+        _, titles = index(tf.constant(["1"]))
+
+    @try_except_assertion_decorator
+    def test_save_and_load(self):
+        """
+        Test that saving and loading works.
+        """
+
+        model = self._generate_default_compiled_model()
+        model.fit(
+                self._train,
+                epochs=self._epochs
+        )
+        index = tfrs.layers.factorized_top_k.BruteForce(model.user_model)
+        index.index_from_dataset(
+                tf.data.Dataset.zip((
+                    self._movies, self._movies.map(model.item_model)
+                ))
+        )
+
+        tf.saved_model.save(index, self.temp)
+        _ = tf.saved_model.load(self.temp)
+
+
+class TestTwoTowerRatingsRanking(RecommenderIntegrationMixin, ModelIntegrationABC, TC):
     """
     Fine tuning tester. For simplicity, here we simply create
     """
 
-    temp = os.path.join(os.getcwd(), "finetuningtwotower-tmp-model")
+    temp = os.path.join(os.getcwd(), "rankingtwotower-tmp-model")
 
     def _generate_default_compiled_model(self):
         """
@@ -121,47 +165,25 @@ class TestFineTuningTwoTower(RecommenderIntegrationMixin, ModelIntegrationABC, T
         item_model = StringEmbedding(
                 vocab=self._items, embedding_dim=self._embedding_dim
         )
-        model = FineTuningTwoTower(
-                task=self._task,
+        ratings_model = MLP(
+                hidden_dims=[4*self._embedding_dim, 2*self._embedding_dim],
+                output_dim=1,
+                activation="relu",
+                output_activation="linear",
+                spectral_norm=True
+        )
+        model = TwoTowerRatingsRanking(
+                ratings_model=ratings_model,
                 user_model=user_model,
                 item_model=item_model,
                 user_features=self._user_features,
-                item_features=self._item_features
+                item_features=self._item_features,
+                ratings_label=self._ratings_label,
         )
         model.compile(
             optimizer=get_obj(tf.keras.optimizers, self._optimizer)
         )
         return model
-
-    def test_fit_ranking(self):
-        """
-        Test that training "works" (by the definition of TrainSanityCallback)
-        for the default model. Assertion is done directly in
-        TrainSanityCallback.
-        """
-        ranking_task = tfrs.tasks.Ranking()
-
-        user_model = StringEmbedding(
-                vocab=self._users, embedding_dim=self._embedding_dim
-        )
-        item_model = StringEmbedding(
-                vocab=self._items, embedding_dim=self._embedding_dim
-        )
-        model = FineTuningTwoTower(
-                task=ranking_task,
-                user_model=user_model,
-                item_model=item_model,
-                user_features=self._user_features,
-                item_features=self._item_features
-        )
-        model.compile(
-            optimizer=get_obj(tf.keras.optimizers, self._optimizer)
-        )
-        model.fit(
-                self._train,
-                epochs=self._epochs,
-                callbacks=[TrainSanityAssertionCallback()]
-        )
 
     @try_except_assertion_decorator
     def test_predict(self):


### PR DESCRIPTION
- Model naming conventions updated to reflect distinction between those intended for ranking vs those for retrieval
- Basic ratings ranking model `TwoTowerRatingsRanking`